### PR TITLE
return string for rails 4 compatibility

### DIFF
--- a/lib/ransack_ui/ransack_overrides/translate.rb
+++ b/lib/ransack_ui/ransack_overrides/translate.rb
@@ -15,7 +15,7 @@ module Ransack
       attribute_names = attributes_str.split(/_and_|_or_/)
       combinator = attributes_str.match(/_and_/) ? :and : :or
       defaults = base_ancestors.map do |klass|
-        :"ransack.attributes.#{klass.model_name.demodulize.downcase.underscore}.#{original_name}"
+        :"ransack.attributes.#{klass.model.name.demodulize.downcase.underscore}.#{original_name}"
       end
 
       translated_names = attribute_names.map do |attr|


### PR DESCRIPTION
* model_name returns an `ActiveModel` object in Rails 4, this does not respond to `demodulize`
There are no similar methods that return singular model names with the same decoration so just use `name`
rails3/4 compatible